### PR TITLE
social media urls

### DIFF
--- a/client/app/main/main.html
+++ b/client/app/main/main.html
@@ -44,7 +44,7 @@
             </ng-form>
             </uib-accordion-group>
             <uib-accordion-group heading="Spread the word" panel-class="menu-info" template-url="group-template.html">
-              <p>Spread the word about this movement on social media or through our full page or ¼ page flyers.
+              <p>Spread the word about this movement on <a href="http://instagram.com/notinphilly">Instagram</a> and <a href="https://www.facebook.com/groups/1625723617652503/">Facebook</a>, using the #NotinPhilly or through our full page or ¼ page flyers.
                   Invite a neighbor to sign up and also go out once a week on your block or take another.
                   We also need "Neighborhood Champions" to distribute grabbers within their neighborhood. If you are interested, email us at <a href="mailto:notinphilly@gmail.com" target="_blank">notinphilly@gmail.com</a>.
               </p>
@@ -70,7 +70,7 @@
               </ul>
             </uib-accordion-group>
             <uib-accordion-group heading="Contact us" panel-class="menu-info" template-url="group-template.html">
-
+                <a href="mailto:notinphilly@gmail.com" target="_blank">notinphilly@gmail.com</a>
             </uib-accordion-group>
           </uib-accordion-group>
         </uib-accordion>
@@ -79,10 +79,8 @@
             <div class="partners-social">
               <div class="row social">
                   <p>SOCIAL</p>
-                  <div class="col-xs-3 col-sm-3 col-md-3"><a href="https://codeforphilly.org/" target="_blank"><img src="public/img/social-instagram.png"></a></div>
-                  <div class="col-xs-3 col-sm-3 col-md-3"><a href="https://codeforphilly.org/" target="_blank"><img src="public/img/social-facebook.png"></a></div>
-                  <div class="col-xs-3 col-sm-3 col-md-3"><a href="https://codeforphilly.org/" target="_blank"><img src="public/img/social-twitter.png"></a></div>
-                  <div class="col-xs-3 col-sm-3 col-md-3"><a href="https://codeforphilly.org/" target="_blank"><img src="public/img/social-youtube.png"></a></div>
+                  <div class="col-xs-3 col-sm-3 col-md-3"><a href="http://instagram.com/notinphilly" target="_blank"><img src="public/img/social-instagram.png"></a></div>
+                  <div class="col-xs-3 col-sm-3 col-md-3"><a href="https://www.facebook.com/groups/1625723617652503/" target="_blank"><img src="public/img/social-facebook.png"></a></div>
               </div>
               <p>SUPPORTED BY</p>
               <div class="row partners">


### PR DESCRIPTION
1. added Instagram and FB urls
2. eliminated twitter and youtube
3. in "spread the word" changed "social media" to "facebook and instragram, using the #NotinPhilly" (urls included)
4. email address (notinphilly@gmail.com) added to Contact us