### PR TITLE
scroll bar on sidebar, not map

### DIFF
--- a/client/app/map/map-template.html
+++ b/client/app/map/map-template.html
@@ -1,6 +1,7 @@
 <div ng-controller="MapController">
   <!--Leaflet map of Philadelphia with layers-->
-  <div resizeleaflet>
+  <!-- <div resizeleaflet> -->
+  <div>
     <leaflet id="cityMap" center="center" geojson="geojson" tiles="tiles" zoomControl="false" width="100%"></leaflet>
   </div>
 

--- a/client/public/css/styles.css
+++ b/client/public/css/styles.css
@@ -1,3 +1,7 @@
+body {
+    overflow: hidden;
+}
+
 p{
     margin: 0;
 }
@@ -33,8 +37,10 @@ input[type*=submit], .btn, .btn-default {
 }
 .side-container {
     z-index: 100;
-    margin-top: -40px;
+    margin-top: -20px;
     padding-right: 0;
+    overflow-y: scroll;
+    max-height: 100vh;
 }
 .side {
     border-right: 1px solid #BDB9BB;
@@ -42,6 +48,7 @@ input[type*=submit], .btn, .btn-default {
     box-shadow: 5px 0 10px -2px rgba(0, 0, 0, 0.2);
     margin-left: -10px;
     z-index: 100;
+    margin-bottom: 40px;
 }
 .offset {
     margin-top: 20px;
@@ -70,7 +77,7 @@ input[type*=submit], .btn, .btn-default {
 }
 
 .logo{
-    margin: 20px 0 10px 0;
+    margin: 0 0 10px 0;
     padding: 20px 10px 10px 10px;
     box-sizing: border-box;
     display: block;


### PR DESCRIPTION
Some CSS changes that prevent the map from making a scroll bar. Instead, the side bar gets the scroll bar.

I've also removed the resizeleaflet property in map-template, which seemed to be buggy when the accordion menus were opened/closed. I left the original there in a comment, and kept the directive in the file system just in case. Tested it on Chrome 47, Safari 9, and Firefox 43.